### PR TITLE
Fix broken links in the README

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/meeting-notes.yml
+++ b/.github/DISCUSSION_TEMPLATE/meeting-notes.yml
@@ -1,12 +1,12 @@
 # https://docs.github.com/en/discussions/managing-discussions-for-your-community/creating-discussion-category-forms
 # https://docs.github.com/en/discussions/managing-discussions-for-your-community/syntax-for-discussion-category-forms
-title: "[Meeting Notes] - "
+title: "[Meeting Notes] "
 body:
   - type: markdown
     attributes:
       value: |
         ## Working Group Meeting Notes
-        Thank you for taking notes! Please fill out this form with the meeting details.
+        Thank you for taking notes! Please fill out this form with the meeting details, and append todays date ( - YYYY-MM-DD) to the above title.
 
   - type: input
     id: meeting-date

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ We have a variety of GitHub templates for Working Group community interaction.
 - [`./.github/DISCUSSION_TEMPLATE/`](./.github/DISCUSSION_TEMPLATE/)
   - [`./.github/DISCUSSION_TEMPLATE/general.yml`](./.github/DISCUSSION_TEMPLATE/general.yml)
     - Usage: For general discussions related to this specific working group.
-    - Form link: <https://github.com/erlef/libs-and-frameworks/discussions/new?category=general-discussion>
+    - Form link: <https://github.com/erlef/libs-and-frameworks/discussions/new?category=general>
   - [`./.github/DISCUSSION_TEMPLATE/meeting-notes.yml`](./.github/DISCUSSION_TEMPLATE/meeting-notes.yml)
     - Usage: Creating during meetings for clerical notes and summaries; this allows non-attendees to see most of what was talked about.
     - Form link: <https://github.com/erlef/libs-and-frameworks/discussions/new?category=meeting-notes>

--- a/README.md
+++ b/README.md
@@ -8,20 +8,20 @@ We have a variety of GitHub templates for Working Group community interaction.
 
 ### WG Issue Templates
 
-- [`./github/ISSUE_TEMPLATE/`](./github/ISSUE_TEMPLATE/)
-  - [`./github/ISSUE_TEMPLATE/agenda-item.md`](./github/ISSUE_TEMPLATE/agenda-item.md)
+- [`./.github/ISSUE_TEMPLATE/`](./.github/ISSUE_TEMPLATE/)
+  - [`./.github/ISSUE_TEMPLATE/agenda-item.md`](./.github/ISSUE_TEMPLATE/agenda-item.md)
     - Usage: questions, comments, or concerns to discuss in an upcoming meeting.
     - Form link: https://github.com/erlef/libs-and-frameworks/issues/new?template=agenda-item.md
-  - [`./github/ISSUE_TEMPLATE/action-item.md`](./github/ISSUE_TEMPLATE/action-item.md)
+  - [`./.github/ISSUE_TEMPLATE/action-item.md`](./.github/ISSUE_TEMPLATE/action-item.md)
     - Usage: completable actions the group would like to accomplish.
     - Form link: https://github.com/erlef/libs-and-frameworks/issues/new?template=action-item.md
 
 ### WG Discussion Templates
 
-- [`./github/DISCUSSION_TEMPLATE/`](./github/DISCUSSION_TEMPLATE/)
-  - [`./github/DISCUSSION_TEMPLATE/general.yml`](./github/DISCUSSION_TEMPLATE/general.yml)
+- [`./.github/DISCUSSION_TEMPLATE/`](./.github/DISCUSSION_TEMPLATE/)
+  - [`./.github/DISCUSSION_TEMPLATE/general.yml`](./.github/DISCUSSION_TEMPLATE/general.yml)
     - Usage: For general discussions related to this specific working group.
     - Form link: https://github.com/erlef/libs-and-frameworks/discussions/new?category=general-discussion
-  - [`./github/DISCUSSION_TEMPLATE/meeting-notes.yml`](./github/DISCUSSION_TEMPLATE/meeting-notes.yml)
+  - [`./.github/DISCUSSION_TEMPLATE/meeting-notes.yml`](./.github/DISCUSSION_TEMPLATE/meeting-notes.yml)
     - Usage: Creating during meetings for clerical notes and summaries; this allows non-attendees to see most of what was talked about.
     - Form link: https://github.com/erlef/libs-and-frameworks/discussions/new?category=meeting-notes

--- a/README.md
+++ b/README.md
@@ -11,17 +11,17 @@ We have a variety of GitHub templates for Working Group community interaction.
 - [`./.github/ISSUE_TEMPLATE/`](./.github/ISSUE_TEMPLATE/)
   - [`./.github/ISSUE_TEMPLATE/agenda-item.md`](./.github/ISSUE_TEMPLATE/agenda-item.md)
     - Usage: questions, comments, or concerns to discuss in an upcoming meeting.
-    - Form link: https://github.com/erlef/libs-and-frameworks/issues/new?template=agenda-item.md
+    - Form link: <https://github.com/erlef/libs-and-frameworks/issues/new?template=agenda-item.md>
   - [`./.github/ISSUE_TEMPLATE/action-item.md`](./.github/ISSUE_TEMPLATE/action-item.md)
     - Usage: completable actions the group would like to accomplish.
-    - Form link: https://github.com/erlef/libs-and-frameworks/issues/new?template=action-item.md
+    - Form link: <https://github.com/erlef/libs-and-frameworks/issues/new?template=action-item.md>
 
 ### WG Discussion Templates
 
 - [`./.github/DISCUSSION_TEMPLATE/`](./.github/DISCUSSION_TEMPLATE/)
   - [`./.github/DISCUSSION_TEMPLATE/general.yml`](./.github/DISCUSSION_TEMPLATE/general.yml)
     - Usage: For general discussions related to this specific working group.
-    - Form link: https://github.com/erlef/libs-and-frameworks/discussions/new?category=general-discussion
+    - Form link: <https://github.com/erlef/libs-and-frameworks/discussions/new?category=general-discussion>
   - [`./.github/DISCUSSION_TEMPLATE/meeting-notes.yml`](./.github/DISCUSSION_TEMPLATE/meeting-notes.yml)
     - Usage: Creating during meetings for clerical notes and summaries; this allows non-attendees to see most of what was talked about.
-    - Form link: https://github.com/erlef/libs-and-frameworks/discussions/new?category=meeting-notes
+    - Form link: <https://github.com/erlef/libs-and-frameworks/discussions/new?category=meeting-notes>


### PR DESCRIPTION
I noticed that all the README that was added in #5 has all of its links broken.

I also attempted to fix the meeting-notes discussion template which currently doesn't show up at all.